### PR TITLE
cors 설정 (vue.js 구동 포트 지정)

### DIFF
--- a/src/main/kotlin/io/chart/lognomy/config/WebMvcConfig.kt
+++ b/src/main/kotlin/io/chart/lognomy/config/WebMvcConfig.kt
@@ -1,0 +1,15 @@
+package io.chart.lognomy.config
+
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.servlet.config.annotation.CorsRegistry
+import org.springframework.web.servlet.config.annotation.EnableWebMvc
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+
+@Configuration
+@EnableWebMvc
+class WebMvcConfig : WebMvcConfigurer{
+    override fun addCorsMappings(registry: CorsRegistry) {
+        registry.addMapping("/**")
+                .allowedOrigins("http://localhost:9090")    // vue.js running port
+    }
+}


### PR DESCRIPTION
cors 설정 (vue.js 구동 포트 지정)
 : 로컬에서 merge 해도 되지만, master 브랜치 병합은 PR로 하도록 해봄 